### PR TITLE
Added restored keys count status report on USR1 signal, and at the end of the sync.

### DIFF
--- a/rump.go
+++ b/rump.go
@@ -86,8 +86,6 @@ func main() {
 	to := flag.String("to", "", "example: redis://127.0.0.1:6379/1")
 	flag.Parse()
 
-	signals.Init(displayRestoredKeysCount)
-
 	source, err := redis.DialURL(*from)
 	handle(err)
 	destination, err := redis.DialURL(*to)
@@ -95,6 +93,8 @@ func main() {
 	defer source.Close()
 	defer destination.Close()
 
+	signals.Init(displayRestoredKeysCount)
+	
 	// Channel where batches of keys will pass.
 	queue := make(chan map[string]string, 100)
 

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package signals
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var signals chan os.Signal
+
+// Init initializes the signal watcher with the handler function that will be invoked on USR1 signal
+func Init(handler func()) {
+	signals = make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGUSR1)
+
+	go handleSignals(handler)
+}
+
+// Invoke the given handler for the USR1 signal
+func handleSignals(handler func()) {
+	for {
+		sig := <-signals
+		if sig == syscall.SIGUSR1 {
+			handler()
+		}
+	}
+}

--- a/signals/signals_windows.go
+++ b/signals/signals_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package signals
+
+// Init initializes the signal watcher with the handler function that will be invoked on USR1 signal
+func Init(handler func()) {
+	// NOOP: Windows doesn't have signals equivalent to the Unix world.
+}


### PR DESCRIPTION
Similar to what the `dd` does when the user sends the USR1 signal, for windows platform, this is a noop.

Also added the same report of restored keys count to be printed at the end of the sync.