### PR TITLE
Pre-compile Windows and ARM binaries.

### DIFF
--- a/multi-arch.sh
+++ b/multi-arch.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 VERSION="$1"
 
-GOOS=darwin GOARCH=amd64 go build -o rump-$VERSION-darwin-amd64 rump.go 
-GOOS=linux GOARCH=amd64 go build -o rump-$VERSION-linux-amd64 rump.go 
+rm rump-*
+GOOS=darwin GOARCH=amd64 go build -o rump-$VERSION-darwin-amd64 rump.go
+GOOS=linux GOARCH=amd64 go build -o rump-$VERSION-linux-amd64 rump.go
+GOOS=linux GOARCH=arm go build -o rump-$VERSION-linux-arm rump.go
+GOOS=windows GOARCH=amd64 go build -o rump-$VERSION-windows-amd64 rump.go


### PR DESCRIPTION
Windows and ARM binaries have been added to the latest release too:
https://github.com/stickermule/rump/releases/tag/0.0.2