### PR TITLE
Don't fail on key not found.

### DIFF
--- a/rump.go
+++ b/rump.go
@@ -9,7 +9,7 @@ import (
 
 // Report all errors to stdout.
 func handle(err error) {
-	if err != nil {
+	if err != nil && err != redis.ErrNil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Redigo raises an error, nil returned, if the key is not found. This can happen for example if SCAN finds a key but on DUMP the key is not there. Rump shouldn't fail on this error because it doesn't affect the sync.