### PR TITLE
tls: add option to connect to redis with enabled tls and auth token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stickermule/rump
 go 1.12
 
 require (
-	github.com/mediocregopher/radix/v3 v3.2.3
+	github.com/mediocregopher/radix/v3 v3.7.1
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed h1:3dQJqqDouawQgl3gBE1PNHKFkJYGEuFb1DbSlaxdosE=
-github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
-github.com/mediocregopher/radix/v3 v3.2.3 h1:TbcGCZdo9zfPYPgevsqRn+OjvCyfOK6TzuXhqzWdCt0=
-github.com/mediocregopher/radix/v3 v3.2.3/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
+github.com/mediocregopher/radix/v3 v3.7.1 h1:o7PGt1yePNGQ+YZ4fwT5BSgcAl+1Mf4T0eRSAHwUxS4=
+github.com/mediocregopher/radix/v3 v3.7.1/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 type Resource struct {
 	URI     string
 	IsRedis bool
+	Auth    string
 }
 
 // Config represents the current source and target config.
@@ -34,27 +35,39 @@ func exit(e error) {
 	os.Exit(1)
 }
 
+// getRedisOptions makes sure provided string is Redis URI,
+// and return is redis or not and auth string if it's specified.
+func getRedisOptions(conn string) (bool, string, string) {
+	var redisPrefix string = "redis://"
+	var authSeparator string = "@"
+	var isRedis bool
+	var auth string
+	var uri string = conn
+
+	if strings.HasPrefix(conn, redisPrefix) {
+		isRedis = true
+
+		if strings.Contains(conn, authSeparator) {
+			auth = strings.Split(strings.TrimPrefix(conn, redisPrefix), authSeparator)[0]
+			uri = redisPrefix + strings.Split(conn, authSeparator)[1]
+		}
+	}
+
+	return isRedis, uri, auth
+}
+
 // validate makes sure from and to are Redis URIs or file paths,
 // and generates the final Config.
 func validate(from, to string, silent, ttl bool) (Config, error) {
 	cfg := Config{
-		Source: Resource{
-			URI: from,
-		},
-		Target: Resource{
-			URI: to,
-		},
+		Source: Resource{},
+		Target: Resource{},
 		Silent: silent,
 		TTL:    ttl,
 	}
 
-	if strings.HasPrefix(from, "redis://") {
-		cfg.Source.IsRedis = true
-	}
-
-	if strings.HasPrefix(to, "redis://") {
-		cfg.Target.IsRedis = true
-	}
+	cfg.Source.IsRedis, cfg.Source.URI, cfg.Source.Auth = getRedisOptions(from)
+	cfg.Target.IsRedis, cfg.Target.URI, cfg.Target.Auth = getRedisOptions(to)
 
 	// Guard from incorrect usage.
 	switch {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,7 +81,7 @@ func validate(from, to string, silent, ttl bool) (Config, error) {
 	}
 
 	cfg.Source.IsRedis, cfg.Source.URI, cfg.Source.Auth, cfg.Source.TLS = getRedisOptions(from)
-	cfg.Target.IsRedis, cfg.Target.URI, cfg.Target.Auth = getRedisOptions(to)
+	cfg.Target.IsRedis, cfg.Target.URI, cfg.Target.Auth, cfg.Source.TLS = getRedisOptions(to)
 
 	// Guard from incorrect usage.
 	switch {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,6 +48,37 @@ func TestFromRedisToRedis(t *testing.T) {
 	}
 }
 
+func TestFromRedisToRedisWithAuth(t *testing.T) {
+	cfg, err := validate("redis://a@s", "redis://b@t", false, false)
+	if err != nil {
+		t.Error("from redis to redis should work")
+	}
+
+	if !cfg.Source.IsRedis {
+		t.Error("wrong from")
+	}
+
+	if !cfg.Target.IsRedis {
+		t.Error("wrong to")
+	}
+
+	if cfg.Source.URI != "redis://s" {
+		t.Error("wrong source")
+	}
+
+	if cfg.Source.Auth != "a" {
+		t.Error("wrong source auth")
+	}
+
+	if cfg.Target.URI != "redis://t" {
+		t.Error("wrong target")
+	}
+
+	if cfg.Target.Auth != "b" {
+		t.Error("wrong target auth")
+	}
+}
+
 func TestFromRedisToFile(t *testing.T) {
 	cfg, err := validate("redis://s", "/t.rump", false, false)
 	if err != nil {

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -3,6 +3,7 @@ package run
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"time"
@@ -23,8 +24,8 @@ func exit(e error) {
 	os.Exit(1)
 }
 
-func authConn(authPass string, tls bool) radix.ConnFunc {
-	if tls {
+func authConn(authPass string, useTls bool) radix.ConnFunc {
+	if useTls {
 		return func(network, address string) (radix.Conn, error) {
 			return radix.Dial(network, address,
 				radix.DialTimeout(1*time.Minute),

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -3,8 +3,10 @@ package run
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/mediocregopher/radix/v3"
 	"golang.org/x/sync/errgroup"
@@ -20,6 +22,16 @@ import (
 func exit(e error) {
 	fmt.Println(e)
 	os.Exit(1)
+}
+
+func authConn(authPass string) radix.ConnFunc {
+	return func(network, address string) (radix.Conn, error) {
+		return radix.Dial(network, address,
+			radix.DialTimeout(1*time.Minute),
+			radix.DialAuthPass(authPass),
+			radix.DialUseTLS(&tls.Config{}),
+		)
+	}
 }
 
 // Run orchestrate the Reader, Writer and Signal handler.
@@ -38,9 +50,21 @@ func Run(cfg config.Config) {
 
 	// Create and run either a Redis or File Source reader.
 	if cfg.Source.IsRedis {
-		db, err := radix.NewPool("tcp", cfg.Source.URI, 1)
-		if err != nil {
-			exit(err)
+		var db *radix.Pool
+		var err error
+
+		if len(cfg.Source.Auth) > 0 {
+			db, err = radix.NewPool("tcp", cfg.Source.URI, 1, radix.PoolConnFunc(authConn(cfg.Source.Auth)))
+
+			if err != nil {
+				exit(err)
+			}
+		} else {
+			db, err = radix.NewPool("tcp", cfg.Source.URI, 1)
+
+			if err != nil {
+				exit(err)
+			}
 		}
 
 		source := redis.New(db, ch, cfg.Silent, cfg.TTL)
@@ -58,9 +82,21 @@ func Run(cfg config.Config) {
 
 	// Create and run either a Redis or File Target writer.
 	if cfg.Target.IsRedis {
-		db, err := radix.NewPool("tcp", cfg.Target.URI, 1)
-		if err != nil {
-			exit(err)
+		var db *radix.Pool
+		var err error
+
+		if len(cfg.Target.Auth) > 0 {
+			db, err = radix.NewPool("tcp", cfg.Target.URI, 1, radix.PoolConnFunc(authConn(cfg.Target.Auth)))
+
+			if err != nil {
+				exit(err)
+			}
+		} else {
+			db, err = radix.NewPool("tcp", cfg.Target.URI, 1)
+
+			if err != nil {
+				exit(err)
+			}
 		}
 
 		target := redis.New(db, ch, cfg.Silent, cfg.TTL)


### PR DESCRIPTION
- [x] I have read the [contributing](docs/CONTRIBUTING.md) guide.
- [x] Issue: https://github.com/stickermule/rump/issues/41

### Implementation

- radix version is upgraded to `v3.7.1` and tested in real environment.
- added auth field to redis [Resource struct](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/config/config.go#L13-L17).
- added new function for retrieving [redis url and auth token](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/config/config.go#L38-L57) in connection string. [It's done for avoiding code duplication](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/config/config.go#L69-L70).
- added new test case for checking [how validation works with auth token](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/config/config_test.go#L51-L80).
- when connecting to redis with auth token we need to define callback to perform authentication and encryption [as described here](https://pkg.go.dev/github.com/mediocregopher/radix.v3#hdr-AUTH_and_other_settings_via_ConnFunc_and_ClientFunc). [Here is implementation](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/run/run.go#L27-L35)
- [Here I check](https://github.com/lanycrost/rump/blob/cc2bbe39d09adc57213aba948348c6d412af59d1/pkg/run/run.go#L53-L68) if auth is enabled we use ConnFunc described above, or your method without authentication (same for target).


Thanks!